### PR TITLE
Fix variable name

### DIFF
--- a/www/js/plugin/storage.js
+++ b/www/js/plugin/storage.js
@@ -18,7 +18,7 @@ angular.module('emission.plugin.kvstore', ['emission.plugin.logger',
      */
 
     var mungeValue = function(key, value) {
-        var storage_val = value;
+        var store_val = value;
         if (typeof value != "object") {
             // Should this be {"value": value} or {key: value}?
             store_val = {};


### PR DESCRIPTION
This is a port of
https://github.com/e-mission/e-mission-phone/pull/470/commits/952165affb264d2696d33732f17bbc64e9d54d83

This bug is actually in the most recent release
https://github.com/e-mission/e-mission-base/releases/tag/v1.1.0

We just got lucky because the only value stored in this extremely stripped down
version is the channel, which is not an object, and so we created the
`store_val` variable in the if block anyway.

Fixing this before the next version