### PR TITLE
Bump up version numbers

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="7" id="edu.berkeley.eecs.embase" ios-CFBundleVersion="7" version="1.1.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="7" id="edu.berkeley.eecs.embase" ios-CFBundleVersion="7" version="1.1.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>emTripLog</name>
     <description>
         Base version of the e-mission app, intended for customization by studies.
@@ -63,7 +63,7 @@
     </plugin>
     <engine name="ios" spec="^4.5.4" />
     <engine name="android" spec="^6.4.0" />
-    <plugin name="edu.berkeley.eecs.emission.cordova.auth" spec="https://github.com/e-mission/cordova-jwt-auth.git#v1.4.0" />
+    <plugin name="edu.berkeley.eecs.emission.cordova.auth" spec="https://github.com/e-mission/cordova-jwt-auth.git#v1.4.1" />
     <plugin name="edu.berkeley.eecs.emission.cordova.comm" spec="https://github.com/e-mission/cordova-server-communication.git#v1.2.0" />
     <plugin name="edu.berkeley.eecs.emission.cordova.datacollection" spec="https://github.com/e-mission/e-mission-data-collection.git#v1.1.0" />
     <plugin name="edu.berkeley.eecs.emission.cordova.serversync" spec="https://github.com/e-mission/cordova-server-sync.git#v1.1.0" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edu.berkeley.eecs.embase",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "displayName": "emTripLog",
   "cordova": {
     "platforms": [
@@ -56,7 +56,7 @@
     "cordova-plugin-whitelist": "~1.3.3",
     "cordova-plugin-x-socialsharing": "~5.2.1",
     "de.appplant.cordova.plugin.local-notification-ios9-fix": "https://github.com/shankari/cordova-plugin-local-notifications.git",
-    "em-cordova-jwt-auth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.4.0",
+    "em-cordova-jwt-auth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.4.1",
     "em-cordova-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.0",
     "e-mission-data-collection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.1.0",
     "em-cordova-server-sync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.1.0",


### PR DESCRIPTION
The only change in this app is the fix for https://github.com/e-mission/cordova-jwt-auth/issues/33 merged from https://github.com/e-mission/cordova-jwt-auth/pull/34

So the only changes are to bump up the version number for the auth plugin AND
to bump up the version number for the app to reflect that there has been a
change.

Pretty simple! This is an iOS only change, so we didn't even have to bump up the integer version number.