### PR TITLE
Switch to the old build system so that cordova can continue to work

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,0 +1,9 @@
+{
+  "ios": {
+    "release": {
+      "buildFlag": [
+        "-UseModernBuildSystem=0"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/apache/cordova-ios/issues/407#issuecomment-422130332

Testing done:
Built from the command line `cordova ios build`, got "BUILD SUCCESSFUL" message